### PR TITLE
Add Animator Parameters introduced in 2020.4.1

### DIFF
--- a/Scripts/LyumaAv3Runtime.cs
+++ b/Scripts/LyumaAv3Runtime.cs
@@ -102,7 +102,7 @@ public class LyumaAv3Runtime : MonoBehaviour
     static HashSet<string> BUILTIN_PARAMETERS = new HashSet<string> {
         "Viseme", "GestureLeft", "GestureLeftWeight", "GestureRight", "GestureRightWeight", "VelocityX", "VelocityY", "VelocityZ", "LocomotionMode", "Upright", "AngularY", "GroundProximity", "Grounded", "Supine", "FootstepDisable", "Seated", "AFK", "TrackingType", "VRMode", "MuteSelf", "InStation"
     };
-    [Header("Built-in locomotion inputs")]
+    [Header("Built-in inputs")]
     public int VisemeI;
     public VisemeIndex VisemeDD;
     private int Viseme;


### PR DESCRIPTION
Context:
VRChat introduces new Animator Parameters:
- TrackingType, Int, Playable, which has 6 legal, non-continuous values: 0, 1, 2, 3, 4, 6. Notice that 5 is not an option.
- VRMode, Int, IK, which is either 1 or 0. This is not a boolean.
- MuteSelf, Bool, Playable.
- InStation, Bool, Playable.

In the main branch:
These Animator Parameters are not available in the "Built-in locomotion inputs" part of the "Lyuma AV3 Runtime" component.

Proposal:
- Rename "Built-in locomotion inputs" section of the "Lyuma AV3 Runtime" component to "Built-in inputs"
- Allow control of TrackingType as an Enumeration dropdown in the "Built-in inputs".
  - The enumeration values will be:
    - 0: Uninitialized
    - 1: GenericRig
    - 2: NoFingers
    - 3: HeadHands
    - 4: HeadHandsHip
    - 6: HeadHandsHipFeet
- Allow control of TrackingType as a Slider in the "Built-in inputs", ranging from 0 to 6, so that the numerical value of the tracking type can be read.
- Allow control of VRMode as a checkbox in the "Built-in inputs", despite being an Int parameters.
- Allow control of MuteSelf as a checkbox in the "Built-in inputs".
- Allow control of InStation as a checkbox in the "Built-in inputs".