### PR TITLE
Add Expressions Menu emulator (without quirks emulation)

### DIFF
--- a/Editor/LyumaAv3EditorSupport.cs
+++ b/Editor/LyumaAv3EditorSupport.cs
@@ -119,6 +119,20 @@ public static class LyumaAv3EditorSupport
                 }
             }
         };
+        LyumaAv3Menu.addRuntimeDelegate = (menu) => {
+            GameObject go = menu.gameObject;
+            try {
+                if (PrefabUtility.IsPartOfAnyPrefab(go)) {
+                    PrefabUtility.UnpackPrefabInstance(go, PrefabUnpackMode.Completely, InteractionMode.AutomatedAction);
+                }
+            } catch (System.Exception) {}
+            int moveUpCalls = go.GetComponents<Component>().Length - 3;
+            if (!PrefabUtility.IsPartOfAnyPrefab(go.GetComponents<Component>()[1])) {
+                for (int i = 0; i < moveUpCalls; i++) {
+                    UnityEditorInternal.ComponentUtility.MoveComponentUp(menu);
+                }
+            }
+        };
     }
 
     // register an event handler when the class is initialized

--- a/Editor/LyumaAv3MenuEditor.cs
+++ b/Editor/LyumaAv3MenuEditor.cs
@@ -1,0 +1,354 @@
+﻿/* Copyright (c) 2020 Lyuma <xn.lyuma@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE. */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+using VRC.SDK3.Avatars.ScriptableObjects;
+
+[CustomEditor(typeof(LyumaAv3Menu))]
+public class LyumaAv3MenuEditor : Editor
+{
+    private readonly Dictionary<Texture2D, Texture2D> _resizedIcons = new Dictionary<Texture2D, Texture2D>();
+    private VRCExpressionsMenu _currentMenu;
+
+    public override void OnInspectorGUI()
+    {
+        var menu = (LyumaAv3Menu)target;
+        if (menu.Runtime == null) return;
+        if (menu.RootMenu == null)
+        {
+            menu.RootMenu = (VRCExpressionsMenu)EditorGUILayout.ObjectField(new GUIContent("Expressions Menu"), null, typeof(VRCExpressionsMenu), false);
+            return;
+        }
+
+        var isInRootMenu = menu.MenuStack.Count == 0;
+        GUILayout.BeginHorizontal();
+        if (GUILayout.Button(menu.IsMenuOpen ? "Close menu" : "Open menu"))
+        {
+            menu.ToggleMenu();
+        }
+
+        if (menu.gameObject.GetComponents<LyumaAv3Menu>().Length == 1)
+        {
+            if (GUILayout.Button("+", GUILayout.Width(20)))
+            {
+                OpenMenuForTwoHandedSupport(menu);
+            }
+        }
+
+        GUILayout.EndHorizontal();
+
+        GUILayout.Label(
+            (isInRootMenu ? "Expressions" : LabelizeMenu()) +
+            (menu.IsMenuOpen ? "" : " [Menu is closed]"),
+            EditorStyles.boldLabel);
+
+        if (!menu.IsMenuOpen) {
+            return;
+        }
+
+        _currentMenu = menu.MenuStack.Count == 0 ? menu.RootMenu : menu.MenuStack.Last().ExpressionsMenu;
+
+        EditorGUI.BeginDisabledGroup(true);
+        EditorGUILayout.ObjectField(_currentMenu, typeof(VRCExpressionsMenu), false);
+        EditorGUI.EndDisabledGroup();
+
+        EditorGUI.BeginDisabledGroup(isInRootMenu || menu.HasActiveControl());
+        if (GUILayout.Button("Back"))
+        {
+            menu.UserBack();
+        }
+        EditorGUI.EndDisabledGroup();
+        for (var controlIndex = 0; controlIndex < _currentMenu.controls.Count; controlIndex++)
+        {
+            var control = _currentMenu.controls[controlIndex];
+            switch (control.type)
+            {
+                case VRCExpressionsMenu.Control.ControlType.Button:
+                    FromToggle(control, "Button");
+                    break;
+                case VRCExpressionsMenu.Control.ControlType.Toggle:
+                    FromToggle(control, "Toggle");
+                    break;
+                case VRCExpressionsMenu.Control.ControlType.SubMenu:
+                    FromSubMenu(control);
+                    break;
+                case VRCExpressionsMenu.Control.ControlType.TwoAxisPuppet:
+                    FromTwoAxis(control, controlIndex);
+                    break;
+                case VRCExpressionsMenu.Control.ControlType.FourAxisPuppet:
+                    FromFourAxis(control, controlIndex);
+                    break;
+                case VRCExpressionsMenu.Control.ControlType.RadialPuppet:
+                    FromRadial(control, controlIndex);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        if (_currentMenu.controls.Count == 0)
+        {
+            EditorGUILayout.LabelField("(This menu has no controls)");
+        }
+    }
+
+    private static void OpenMenuForTwoHandedSupport(LyumaAv3Menu menu)
+    {
+        var mainMenu = menu.Runtime.gameObject.AddComponent<LyumaAv3Menu>();
+        mainMenu.Runtime = menu.Runtime;
+        mainMenu.RootMenu = menu.RootMenu;
+    }
+
+    private string LabelizeMenu()
+    {
+        var menu = (LyumaAv3Menu)target;
+
+        var lastMenu = menu.MenuStack.Last();
+        if (lastMenu.MandatedParam == null)
+        {
+            return lastMenu.ExpressionsMenu.name;
+        }
+
+        return lastMenu.ExpressionsMenu.name + " (" + lastMenu.MandatedParam.name + " = " + lastMenu.MandatedParam.value + ")";
+    }
+
+    private void FromToggle(VRCExpressionsMenu.Control control, string labelType)
+    {
+        var menu = (LyumaAv3Menu)target;
+
+        var parameterName = control.parameter.name;
+        var intValue = (int) control.value;
+
+        var isActive = menu.IsVisualActive(parameterName, intValue);
+
+        EditorGUILayout.BeginHorizontal();
+        EditorGUI.BeginDisabledGroup(menu.HasActiveControl());
+        if (GreenBackground(isActive, () => ParameterizedButton(control, parameterName, intValue)))
+        {
+            menu.UserToggle(parameterName, intValue);
+        }
+        EditorGUI.EndDisabledGroup();
+        LabelType(labelType);
+        EditorGUILayout.EndHorizontal();
+    }
+
+    private void FromSubMenu(VRCExpressionsMenu.Control control)
+    {
+        var menu = (LyumaAv3Menu)target;
+
+        var parameterName = control.parameter.name;
+        var intValue = (int) control.value;
+
+        EditorGUILayout.BeginHorizontal();
+        EditorGUI.BeginDisabledGroup(menu.HasActiveControl());
+        if (ParameterizedButton(control, parameterName, intValue))
+        {
+            if (IsValidParameterName(parameterName))
+            {
+                menu.UserSubMenu(control.subMenu, parameterName, intValue);
+            }
+            else
+            {
+                menu.UserSubMenu(control.subMenu);
+            }
+        }
+        EditorGUI.EndDisabledGroup();
+        LabelType("SubMenu");
+        EditorGUILayout.EndHorizontal();
+    }
+
+    private void FromRadial(VRCExpressionsMenu.Control control, int controlIndex)
+    {
+        var menu = (LyumaAv3Menu)target;
+
+        SubControl(control, controlIndex, menu, "Radial");
+
+        if (menu.IsActiveControl(controlIndex))
+        {
+            if (control.subParameters.Length > 0)
+            {
+                SliderFloat(menu, control.subParameters[0], "Rotation", 0f, 1f);
+            }
+        }
+    }
+
+    private void FromTwoAxis(VRCExpressionsMenu.Control control, int controlIndex)
+    {
+        var menu = (LyumaAv3Menu)target;
+
+        SubControl(control, controlIndex, menu, "TwoAxis");
+
+        if (menu.IsActiveControl(controlIndex))
+        {
+            var sanitySubParamLength = control.subParameters.Length;
+            if (sanitySubParamLength > 0) SliderFloat(menu, control.subParameters[0], "Horizontal", -1f, 1f);
+            if (sanitySubParamLength > 1) SliderFloat(menu, control.subParameters[1], "Vertical", -1f, 1f);
+
+            var oldColor = Color.HSVToRGB(
+                0,
+                sanitySubParamLength > 0 ? menu.FindFloat(control.subParameters[0].name) * 0.5f + 0.5f : 0,
+                sanitySubParamLength > 1 ? menu.FindFloat(control.subParameters[1].name) * 0.5f + 0.5f : 0);
+            var newColor = EditorGUILayout.ColorField(oldColor);
+            if (oldColor.r != newColor.r || oldColor.g != newColor.g || oldColor.b != newColor.b)
+            {
+                Color.RGBToHSV(newColor, out _, out var s, out var v);
+                if (sanitySubParamLength > 0) menu.UserFloat(control.subParameters[0].name, s  * 2 - 1);
+                if (sanitySubParamLength > 1) menu.UserFloat(control.subParameters[1].name, v * 2 - 1);
+            }
+        }
+    }
+
+    private void FromFourAxis(VRCExpressionsMenu.Control control, int controlIndex)
+    {
+        var menu = (LyumaAv3Menu)target;
+
+        SubControl(control, controlIndex, menu, "FourAxis");
+
+        if (menu.IsActiveControl(controlIndex))
+        {
+            var sanitySubParamLength = control.subParameters.Length;
+            if (sanitySubParamLength > 0) SliderFloat(menu, control.subParameters[0], "Up", 0f, 1f);
+            if (sanitySubParamLength > 1) SliderFloat(menu, control.subParameters[1], "Right", 0f, 1f);
+            if (sanitySubParamLength > 2) SliderFloat(menu, control.subParameters[2], "Down", 0f, 1f);
+            if (sanitySubParamLength > 3) SliderFloat(menu, control.subParameters[3], "Left", 0f, 1f);
+
+            var oldColor = Color.HSVToRGB(
+                0,
+                (sanitySubParamLength > 0 ? menu.FindFloat(control.subParameters[0].name) : 0) * 0.5f + 0.5f
+                -(sanitySubParamLength > 2 ? menu.FindFloat(control.subParameters[2].name) : 0) * 0.5f + 0.5f,
+                (sanitySubParamLength > 1 ? menu.FindFloat(control.subParameters[1].name) : 0) * 0.5f + 0.5f
+                -(sanitySubParamLength > 3 ? menu.FindFloat(control.subParameters[3].name) : 0) * 0.5f + 0.5f);
+            var newColor = EditorGUILayout.ColorField(oldColor);
+            if (oldColor.r != newColor.r || oldColor.g != newColor.g || oldColor.b != newColor.b)
+            {
+                Color.RGBToHSV(newColor, out _, out var s, out var v);
+                if (sanitySubParamLength > 0) menu.UserFloat(control.subParameters[0].name, Mathf.Clamp(v  * 2 - 1, 0f, 1f));
+                if (sanitySubParamLength > 1) menu.UserFloat(control.subParameters[1].name, Mathf.Clamp(s  * 2 - 1, 0f, 1f));
+                if (sanitySubParamLength > 2) menu.UserFloat(control.subParameters[2].name, -Mathf.Clamp(v  * 2 - 1, -1f, 0f));
+                if (sanitySubParamLength > 3) menu.UserFloat(control.subParameters[3].name, -Mathf.Clamp(s  * 2 - 1, -1f, 0f));
+            }
+        }
+    }
+
+    private void SubControl(VRCExpressionsMenu.Control control, int controlIndex, LyumaAv3Menu menu, string labelType)
+    {
+        var parameterName = control.parameter.name;
+        var intValue = (int) control.value;
+
+        var isActive = menu.IsVisualActive(parameterName, intValue);
+
+        EditorGUILayout.BeginHorizontal();
+        EditorGUI.BeginDisabledGroup(menu.HasActiveControl() && !menu.IsActiveControl(controlIndex));
+        if (GreenBackground(isActive || menu.IsActiveControl(controlIndex), () => ParameterizedButton(control, parameterName, intValue)))
+        {
+            if (!menu.IsActiveControl(controlIndex))
+            {
+                if (IsValidParameterName(parameterName))
+                {
+                    menu.UserControlEnter(controlIndex, parameterName, intValue);
+                }
+                else
+                {
+                    menu.UserControlEnter(controlIndex);
+                }
+            }
+            else
+            {
+                menu.UserControlExit();
+            }
+        }
+
+        EditorGUI.EndDisabledGroup();
+        LabelType(labelType);
+        EditorGUILayout.EndHorizontal();
+    }
+
+    private static void SliderFloat(LyumaAv3Menu menu, VRCExpressionsMenu.Control.Parameter subParam, string intent, float left, float right)
+    {
+        if (subParam == null || subParam.name == "")
+        {
+            EditorGUI.BeginDisabledGroup(true);
+            EditorGUILayout.Slider(intent, 0, left, right);
+            EditorGUI.EndDisabledGroup();
+            return;
+        }
+
+        menu.UserFloat(subParam.name, EditorGUILayout.Slider(intent + " (" + subParam.name + ")", menu.FindFloat(subParam.name), left, right));
+    }
+
+    private bool ParameterizedButton(VRCExpressionsMenu.Control control, string parameterName, int intValue)
+    {
+        var hasParameter = IsValidParameterName(parameterName);
+        return GUILayout.Button(new GUIContent(control.name + (hasParameter ? " (" + parameterName + " = " + intValue + ")" : ""), ResizedIcon(control.icon)));
+    }
+
+    private Texture2D ResizedIcon(Texture2D originalIcon)
+    {
+        if (_resizedIcons.ContainsKey(originalIcon))
+        {
+            return _resizedIcons[originalIcon];
+        }
+
+        var resizedIcon = GenerateResizedIcon(originalIcon, 32);
+        _resizedIcons[originalIcon] = resizedIcon;
+        return resizedIcon;
+    }
+
+    private static Texture2D GenerateResizedIcon(Texture2D originalIcon, int width)
+    {
+        var render = new RenderTexture(width, width, 24);
+        RenderTexture.active = render;
+        Graphics.Blit(originalIcon, render);
+
+        var resizedIcon = new Texture2D(width, width);
+        resizedIcon.ReadPixels(new Rect(0, 0, width, width), 0, 0);
+        resizedIcon.Apply();
+
+        return resizedIcon;
+    }
+
+    private static T GreenBackground<T>(bool isActive, Func<T> inside)
+    {
+        var col = GUI.color;
+        try
+        {
+            if (isActive) GUI.color = Color.green;
+            return inside();
+        }
+        finally
+        {
+            GUI.color = col;
+        }
+    }
+
+    private static void LabelType(string toggle)
+    {
+        EditorGUILayout.LabelField(toggle, GUILayout.Width(70), GUILayout.ExpandHeight(true));
+    }
+
+    private static bool IsValidParameterName(string parameterName)
+    {
+        return !string.IsNullOrEmpty(parameterName);
+    }
+}

--- a/Editor/LyumaAv3MenuEditor.cs.meta
+++ b/Editor/LyumaAv3MenuEditor.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 187ea10b8ccd4441a6399698c23122e3
+timeCreated: 1604152513

--- a/Scripts/LyumaAv3Emulator.cs
+++ b/Scripts/LyumaAv3Emulator.cs
@@ -48,7 +48,12 @@ public class LyumaAv3Emulator : MonoBehaviour
         foreach (var avadesc in avatars)
         {
             // Creates the playable director, and initializes animator.
-            runtimes.Add(avadesc.gameObject.GetOrAddComponent<LyumaAv3Runtime>());
+            var runtime = avadesc.gameObject.GetOrAddComponent<LyumaAv3Runtime>();
+            runtimes.Add(runtime);
+
+            var mainMenu = avadesc.gameObject.AddComponent<LyumaAv3Menu>();
+            mainMenu.Runtime = runtime;
+            mainMenu.RootMenu = avadesc.expressionsMenu;
         }
     }
     private void OnDisable() {

--- a/Scripts/LyumaAv3Menu.cs
+++ b/Scripts/LyumaAv3Menu.cs
@@ -1,0 +1,187 @@
+﻿/* Copyright (c) 2020 Lyuma <xn.lyuma@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE. */
+
+using System;
+using UnityEngine;
+using System.Collections.Generic;
+using VRC.SDK3.Avatars.ScriptableObjects;
+
+[RequireComponent(typeof(Animator))]
+public class LyumaAv3Menu : MonoBehaviour
+{
+    [Serializable]
+    public class MenuConditional
+    {
+        public VRCExpressionsMenu ExpressionsMenu { get; }
+        public LyumaAv3Runtime.IntParam MandatedParam { get; }
+
+        public MenuConditional(VRCExpressionsMenu expressionsMenu)
+        {
+            ExpressionsMenu = expressionsMenu;
+        }
+
+        public MenuConditional(VRCExpressionsMenu expressionsMenu, LyumaAv3Runtime.IntParam mandatedParam)
+        {
+            ExpressionsMenu = expressionsMenu;
+            MandatedParam = mandatedParam;
+        }
+
+        bool ShouldMenuRemainOpen(List<LyumaAv3Runtime.IntParam> allConditions)
+        {
+            if (MandatedParam == null) return true;
+
+            var actualParam = allConditions.Find(param => param.name == MandatedParam.name);
+            if (actualParam == null) return false;
+            return actualParam.value == MandatedParam.value;
+        }
+    }
+
+    public LyumaAv3Runtime Runtime;
+    public VRCExpressionsMenu RootMenu;
+    public List<MenuConditional> MenuStack { get; } = new List<MenuConditional>();
+    public bool IsMenuOpen { get; private set; }
+    private int? _activeControlIndex = null;
+    private LyumaAv3Runtime.IntParam _activeControlParameter;
+
+    public delegate void AddRuntime(LyumaAv3Menu runtime);
+    public static AddRuntime addRuntimeDelegate;
+
+    private void Awake()
+    {
+        IsMenuOpen = true;
+
+        if (addRuntimeDelegate != null) {
+            addRuntimeDelegate(this);
+        }
+    }
+
+    public void ToggleMenu()
+    {
+        if (IsMenuOpen && _activeControlIndex != null)
+        {
+            UserControlExit();
+        }
+
+        IsMenuOpen = !IsMenuOpen;
+    }
+
+    public void UserToggle(string paramName, int intValue)
+    {
+        var currentValue = Runtime.Ints.Find(param => param.name == paramName).value;
+        var newValue = intValue == currentValue ? 0 : intValue;
+        DoSetRuntimeInt(paramName, newValue);
+    }
+
+    public void UserSubMenu(VRCExpressionsMenu subMenu)
+    {
+        MenuStack.Add(new MenuConditional(subMenu));
+    }
+
+    public void UserSubMenu(VRCExpressionsMenu subMenu, string paramName, int intValue)
+    {
+        MenuStack.Add(new MenuConditional(subMenu, new LyumaAv3Runtime.IntParam {name = paramName, value = intValue}));
+        DoSetRuntimeInt(paramName, intValue);
+    }
+
+    public void UserBack()
+    {
+        if (MenuStack.Count == 0) return;
+        if (_activeControlIndex != null) return;
+
+        var lastIndex = MenuStack.Count - 1;
+
+        var last = MenuStack[lastIndex];
+        if (last.MandatedParam != null)
+        {
+            DoSetRuntimeInt(last.MandatedParam.name, 0);
+        }
+        MenuStack.RemoveAt(lastIndex);
+    }
+
+    public void UserControlEnter(int controlIndex)
+    {
+        if (_activeControlIndex != null) return;
+
+        _activeControlIndex = controlIndex;
+    }
+
+    public void UserControlEnter(int controlIndex, string paramName, int intValue)
+    {
+        if (_activeControlIndex != null) return;
+
+        _activeControlIndex = controlIndex;
+        _activeControlParameter = new LyumaAv3Runtime.IntParam {name = paramName, value = intValue};
+        DoSetRuntimeInt(paramName, intValue);
+    }
+
+    public void UserControlExit()
+    {
+        if (_activeControlIndex == null) return;
+
+        if (_activeControlParameter != null)
+        {
+            DoSetRuntimeInt(_activeControlParameter.name, 0);
+        }
+        _activeControlIndex = null;
+        _activeControlParameter = null;
+    }
+
+    private void DoSetRuntimeInt(string paramName, int newValue)
+    {
+        var intParam = Runtime.Ints.Find(param => param.name == paramName);
+        if (intParam == null) return;
+
+        intParam.value = newValue;
+    }
+
+    public bool IsVisualActive(string paramName, int value)
+    {
+        var intParam = Runtime.Ints.Find(param => param.name == paramName);
+        if (intParam == null) return false;
+
+        return intParam.value == value;
+    }
+
+    public float FindFloat(string paramName)
+    {
+        var floatParam = Runtime.Floats.Find(param => param.name == paramName);
+        if (floatParam == null) return 0;
+
+        return floatParam.value;
+    }
+
+    public void UserFloat(string paramName, float newValue)
+    {
+        var floatParam = Runtime.Floats.Find(param => param.name == paramName);
+        if (floatParam == null) return;
+
+        floatParam.value = newValue;
+    }
+
+    public bool HasActiveControl()
+    {
+        return _activeControlIndex != null;
+    }
+
+    public bool IsActiveControl(int controlIndex)
+    {
+        return _activeControlIndex == controlIndex;
+    }
+}

--- a/Scripts/LyumaAv3Menu.cs.meta
+++ b/Scripts/LyumaAv3Menu.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 3865e5f6001a4a9286e8c3f33314c306
+timeCreated: 1604151153


### PR DESCRIPTION
Context:
AV3 Emulator allows editing stage values manually for testing purposes.
In a game setting, user inputs are driven by their use of the Expressions menu.

In the main branch:
There is no Expression menu integration in the emulator. The user interaction with the menu cannot be tested.

Proposal:
Add an emulation capable of supporting up to two open Expression menus.
The Expression menus will need to emulate the internal state of the menu.
The user should be able to navigate the menu and their interactions should affect the parameters.

---

The menu will require further development to support "quirks" - behaviors that are not immediately obvious -, which is not part of this proposal. These quirks may include:

- A parameter is changed externally while inside a control or when inside a submenu that changes a parameter.
- Two menus or controls are actively modifying the same parameters.
- A control is modifying the same parameter multiple times.
- Specific behavior when controls are "closed" by the user by pressing the Expression menu button.
- Specific behavior when submenus are "closed" by the user by pressing the Expression menu button.
- Specific behavior when the active submenu has a parameter that suddenly changes.
- Specific behavior when going back from a submenu to another submenu that changes a parameter.
- Specific behavior when going forwards from a submenu to another submenu that changes the same parameter shared by both submenus.