### PR TITLE
Fix Random on VRC Parameter Driver excluding max

### DIFF
--- a/Scripts/LyumaAv3Emulator.cs
+++ b/Scripts/LyumaAv3Emulator.cs
@@ -27,7 +27,7 @@ public class LyumaAv3Emulator : MonoBehaviour
     public bool DefaultToVR = false;
     public bool DefaultTestInStation = false;
     public LyumaAv3Runtime.TrackingTypeIndex DefaultTrackingType = LyumaAv3Runtime.TrackingTypeIndex.HeadHands;
-    public VRCAvatarDescriptor.AnimLayerType DefaultAnimatorToDebug = VRCAvatarDescriptor.AnimLayerType.Base;
+    public VRCAvatarDescriptor.AnimLayerType DefaultAnimatorToDebug = VRCAvatarDescriptor.AnimLayerType.FX;
     public bool RestartEmulator;
     private bool RestartingEmulator;
     public bool CreateNonLocalClone;
@@ -65,7 +65,10 @@ public class LyumaAv3Emulator : MonoBehaviour
     }
     private void OnDisable() {
         foreach (var runtime in runtimes) {
-            runtime.enabled = false;
+            if (runtime != null)
+            {
+                runtime.enabled = false;
+            }
         }
     }
     private void OnEnable() {

--- a/Scripts/LyumaAv3Emulator.cs
+++ b/Scripts/LyumaAv3Emulator.cs
@@ -27,7 +27,7 @@ public class LyumaAv3Emulator : MonoBehaviour
     public bool DefaultToVR = false;
     public bool DefaultTestInStation = false;
     public LyumaAv3Runtime.TrackingTypeIndex DefaultTrackingType = LyumaAv3Runtime.TrackingTypeIndex.HeadHands;
-    public VRCAvatarDescriptor.AnimLayerType DefaultAnimatorToDebug = VRCAvatarDescriptor.AnimLayerType.FX;
+    public VRCAvatarDescriptor.AnimLayerType DefaultAnimatorToDebug = VRCAvatarDescriptor.AnimLayerType.Base;
     public bool RestartEmulator;
     private bool RestartingEmulator;
     public bool CreateNonLocalClone;

--- a/Scripts/LyumaAv3Runtime.cs
+++ b/Scripts/LyumaAv3Runtime.cs
@@ -333,7 +333,7 @@ public class LyumaAv3Runtime : MonoBehaviour
                                 runtime.Ints[idx].value += (int)parameter.value;
                                 break;
                             case VRC.SDKBase.VRC_AvatarParameterDriver.ChangeType.Random:
-                                runtime.Ints[idx].value = UnityEngine.Random.Range((int)parameter.valueMin, (int)parameter.valueMax);
+                                runtime.Ints[idx].value = UnityEngine.Random.Range((int)parameter.valueMin, (int)parameter.valueMax + 1);
                                 break;
                         }
                     }


### PR DESCRIPTION
I would like to merge one small bug fix and a tweak to the Avatars 3.0 Emulator.
- The Random mode on the VRC Parameter Driver for integers was excluding the max value (the int version of Unity.Random.Range is being called for some reason, where max is exclusive).
- Prevent the MissingReferenceException every time Playmode is exited while the Emulator Control is enabled.