### PR TITLE
Remove line implicitly setting all layers to active

### DIFF
--- a/Scripts/LyumaAv3Runtime.cs
+++ b/Scripts/LyumaAv3Runtime.cs
@@ -942,7 +942,6 @@ public class LyumaAv3Runtime : MonoBehaviour
             PlayableBlendingState pbs = new PlayableBlendingState();
             for (int j = 0; j < humanAnimatorPlayable.GetLayerCount(); j++)
             {
-                humanAnimatorPlayable.SetLayerWeight(j, 1f);
                 pbs.layerBlends.Add(new BlendingState());
             }
 


### PR DESCRIPTION
Not sure what the purpose of this line is, but it makes layers with no weight show up when running the simulator, which is inaccurate to how avatars behave in VRChat.