### PR TITLE
AngularY float range to match smooth turn in VR

### DIFF
--- a/Scripts/LyumaAv3Runtime.cs
+++ b/Scripts/LyumaAv3Runtime.cs
@@ -130,7 +130,7 @@ public class LyumaAv3Runtime : MonoBehaviour
     [Range(0, 1)] public float GestureRightWeight;
     [Header("Built-in inputs / Locomotion")]
     public Vector3 Velocity;
-    [Range(-1, 1)] public float AngularY;
+    [Range(-400, 400)] public float AngularY;
     [Range(0, 1)] public float Upright;
     [Range(-1, 1)] public float GroundProximity; // Not implemented
     private int LocomotionMode; // Does not exist.


### PR DESCRIPTION
The emulator currently locks the AngularY float range from -1 to 1, which is only **0.25%** of the default smooth turning speed in-game. This makes the AngularY float useless to test using this emulator.

This pull request changes the range to be -400 to 400, matching the values seen in game while rotating in VR.
_(you can go even higher with a mouse or spinning irl, but this is a nice reference to develop with)_

This enables me to test Fake Dynamics and other useful things using AngularY outside of the animator window:

https://user-images.githubusercontent.com/37721153/141721427-849eaa09-e8dc-44c2-9ba9-d7bf795ac31f.mp4