### PR TITLE
Fix contact/physbone receivers on nonlocal avatars

### DIFF
--- a/Scripts/LyumaAv3Runtime.cs
+++ b/Scripts/LyumaAv3Runtime.cs
@@ -149,16 +149,16 @@ public class LyumaAv3Runtime : MonoBehaviour
             get {
                 // Debug.Log(paramName + " GETb");
                 int idx;
-                // if (runtime.IntToIndex.TryGetValue(paramName, out idx)) return runtime.Ints[idx].value != 0;
-                // if (runtime.FloatToIndex.TryGetValue(paramName, out idx))return runtime.Floats[idx].value != 0.0f;
+                if (runtime.IntToIndex.TryGetValue(paramName, out idx)) return runtime.Ints[idx].value != 0;
+                if (runtime.FloatToIndex.TryGetValue(paramName, out idx))return runtime.Floats[idx].value != 0.0f;
                 if (runtime.BoolToIndex.TryGetValue(paramName, out idx)) return runtime.Bools[idx].value;
                 return false;
             }
             set {
                 // Debug.Log(paramName + " SETb " + value);
                 int idx;
-                // if (runtime.IntToIndex.TryGetValue(paramName, out idx)) runtime.Ints[idx].value = value ? 1 : 0;
-                // if (runtime.FloatToIndex.TryGetValue(paramName, out idx)) runtime.Floats[idx].value = value ? 1.0f : 0.0f;
+                if (runtime.IntToIndex.TryGetValue(paramName, out idx)) runtime.Ints[idx].value = value ? 1 : 0;
+                if (runtime.FloatToIndex.TryGetValue(paramName, out idx)) runtime.Floats[idx].value = value ? 1.0f : 0.0f;
                 if (runtime.BoolToIndex.TryGetValue(paramName, out idx)) runtime.Bools[idx].value = value;
             }
         }
@@ -167,33 +167,33 @@ public class LyumaAv3Runtime : MonoBehaviour
                 int idx;
                 // Debug.Log(paramName + " GETi");
                 if (runtime.IntToIndex.TryGetValue(paramName, out idx)) return runtime.Ints[idx].value;
-                // if (runtime.FloatToIndex.TryGetValue(paramName, out idx)) return (int)runtime.Floats[idx].value;
-                // if (runtime.BoolToIndex.TryGetValue(paramName, out idx)) return runtime.Bools[idx].value ? 1 : 0;
+                if (runtime.FloatToIndex.TryGetValue(paramName, out idx)) return (int)runtime.Floats[idx].value;
+                if (runtime.BoolToIndex.TryGetValue(paramName, out idx)) return runtime.Bools[idx].value ? 1 : 0;
                 return 0;
             }
             set {
                 // Debug.Log(paramName + " SETi " + value);
                 int idx;
                 if (runtime.IntToIndex.TryGetValue(paramName, out idx)) runtime.Ints[idx].value = value;
-                // if (runtime.FloatToIndex.TryGetValue(paramName, out idx)) runtime.Floats[idx].value = (float)value;
-                // if (runtime.BoolToIndex.TryGetValue(paramName, out idx)) runtime.Bools[idx].value = value != 0;
+                if (runtime.FloatToIndex.TryGetValue(paramName, out idx)) runtime.Floats[idx].value = (float)value;
+                if (runtime.BoolToIndex.TryGetValue(paramName, out idx)) runtime.Bools[idx].value = value != 0;
             }
         }
         public float floatVal {
             get {
                 // Debug.Log(paramName + " GETf");
                 int idx;
-                // if (runtime.IntToIndex.TryGetValue(paramName, out idx)) return (float)runtime.Ints[idx].value;
+                if (runtime.IntToIndex.TryGetValue(paramName, out idx)) return (float)runtime.Ints[idx].value;
                 if (runtime.FloatToIndex.TryGetValue(paramName, out idx)) return runtime.Floats[idx].value;
-                // if (runtime.BoolToIndex.TryGetValue(paramName, out idx)) return runtime.Bools[idx].value ? 1.0f : 0.0f;
+                if (runtime.BoolToIndex.TryGetValue(paramName, out idx)) return runtime.Bools[idx].value ? 1.0f : 0.0f;
                 return 0.0f;
             }
             set {
                 // Debug.Log(paramName + " SETf " + value);
                 int idx;
-                // if (runtime.IntToIndex.TryGetValue(paramName, out idx)) runtime.Ints[idx].value = (int)value;
+                if (runtime.IntToIndex.TryGetValue(paramName, out idx)) runtime.Ints[idx].value = (int)value;
                 if (runtime.FloatToIndex.TryGetValue(paramName, out idx)) runtime.Floats[idx].value = value;
-                // if (runtime.BoolToIndex.TryGetValue(paramName, out idx)) runtime.Bools[idx].value = value != 0.0f;
+                if (runtime.BoolToIndex.TryGetValue(paramName, out idx)) runtime.Bools[idx].value = value != 0.0f;
             }
         }
     }

--- a/Scripts/LyumaAv3Runtime.cs
+++ b/Scripts/LyumaAv3Runtime.cs
@@ -280,6 +280,7 @@ public class LyumaAv3Runtime : MonoBehaviour
                 accessInst.runtime = this;
                 accessInst.paramName = parameter;
                 contactReceiverState.paramAccess.SetValue(mb, accessInst);
+                accessInst.floatVal = (float)contactReceiverState.paramValue.GetValue(mb);
                 // Debug.Log("Assigned access " + contactReceiverState.paramAccess.GetValue(mb) + " to param " + parameter + ": was " + old_value);
             }
         }
@@ -291,14 +292,17 @@ public class LyumaAv3Runtime : MonoBehaviour
                 accessInst.runtime = this;
                 accessInst.paramName = parameter + PhysBoneState.PARAM_ANGLE;
                 physBoneState.param_Angle.SetValue(mb, accessInst);
+                accessInst.floatVal = (float) physBoneState.param_AngleValue.GetValue(mb);
                 accessInst = (Av3EmuParameterAccessBase)accessClass.GetConstructor(new System.Type[0]).Invoke(new object[0]);
                 accessInst.runtime = this;
                 accessInst.paramName = parameter + PhysBoneState.PARAM_ISGRABBED;
                 physBoneState.param_IsGrabbed.SetValue(mb, accessInst);
+                accessInst.boolVal = (bool)physBoneState.param_IsGrabbedValue.GetValue(mb);
                 accessInst = (Av3EmuParameterAccessBase)accessClass.GetConstructor(new System.Type[0]).Invoke(new object[0]);
                 accessInst.runtime = this;
                 accessInst.paramName = parameter + PhysBoneState.PARAM_STRETCH;
                 physBoneState.param_Stretch.SetValue(mb, accessInst);
+                accessInst.floatVal = (float)physBoneState.param_StretchValue.GetValue(mb);
                 // Debug.Log("Assigned strech access " + physBoneState.param_Stretch.GetValue(mb) + " to param " + parameter + ": was " + old_value);
             }
         }
@@ -2203,7 +2207,9 @@ public class LyumaAv3Runtime : MonoBehaviour
             whichcontroller++;
         }
 
-        if (emulator != null && !emulator.DisableAvatarDynamicsIntegration) {
+        if ((emulator != null && !emulator.DisableAvatarDynamicsIntegration)
+            || (AvatarSyncSource?.emulator != null && !AvatarSyncSource.emulator.DisableAvatarDynamicsIntegration))
+        {
             assignPhysBoneParameters();
         }
 


### PR DESCRIPTION
This fixes two bugs resulting in contacts and physbone parameters not
working on nonlocal avatars:

1. Because the `emulator` field is null on nonlocal avatars,
   `assignPhysBoneParameters()` was not being called.  Here, we update
   the condition to consult the parent avatar for nonlocal clones.

2. The parameter assignment seems to happen after the initial value of
   the contact is set by the VRCSDK, so the accessor was not being
   consulted until the value of the contact changed at least once. Here,
   we assign the parameter value explicitly when we change out the
   accessor to patch over this race condition. There's probably a
   cleaner solution, but I don't understand the order of events well
   enough to propose it.

Note: I've not fully tested the PhysBone path here, but it shouldn't
break... I think?

Note[2]: Changing the displayed layer on the nonlocal clone will also
reset the parameter values. I'm not sure how to avoid this.

Fixes: #34 