### PR TITLE
Invoke avatar preprocessing hooks when initializing the emulator

### DIFF
--- a/Editor/LyumaAv3EditorSupport.cs
+++ b/Editor/LyumaAv3EditorSupport.cs
@@ -27,6 +27,7 @@ using UnityEditor.Compilation;
 using UnityEditor.Playables;
 using UnityEngine.Playables;
 using VRC.SDK3.Avatars.Components;
+using VRC.SDKBase.Editor.BuildPipeline;
 
 [InitializeOnLoadAttribute]
 public static class LyumaAv3EditorSupport
@@ -250,6 +251,10 @@ public static class LyumaAv3EditorSupport
     {
         InitDefaults();
         EditorApplication.playModeStateChanged += OnPlayModeStateChange;
+        LyumaAv3Runtime.InvokeOnPreProcessAvatar = (obj) =>
+        {
+            VRCBuildPipelineCallbacks.OnPreprocessAvatar(obj);
+        };
     }
 
     [MenuItem("Tools/Enable Avatars 3.0 Emulator")]

--- a/Scripts/LyumaAv3Runtime.cs
+++ b/Scripts/LyumaAv3Runtime.cs
@@ -42,6 +42,9 @@ public class LyumaAv3Runtime : MonoBehaviour
     public delegate void ApplyOnEnableWorkaroundDelegateType();
     public static ApplyOnEnableWorkaroundDelegateType ApplyOnEnableWorkaroundDelegate;
 
+    // This is injected by Editor-scope scripts to give us access to VRCBuildPipelineCallbacks.
+    public static Action<GameObject> InvokeOnPreProcessAvatar = (_) => { };
+
     public LyumaAv3Runtime OriginalSourceClone = null;
 
     [Tooltip("Resets avatar state machine instantly")]
@@ -851,6 +854,12 @@ public class LyumaAv3Runtime : MonoBehaviour
             Debug.Log("Deduplicating Awake() call if we already got awoken by our children.", this);
             return;
         }
+
+        if (OriginalSourceClone == null)
+        {
+            InvokeOnPreProcessAvatar(gameObject);
+        }
+
         // Debug.Log("AWOKEN " + gameObject.name, this);
         attachedAnimators = new HashSet<Animator>();
         if (AvatarSyncSource == null) {


### PR DESCRIPTION
When writing editor scripts for avatars that run via build hooks, it can be helpful to have them work when the Av3Emulator is running as well. However, currently the Av3Runtime reads a bunch of data from the avatar descriptor in Awake, and there's not a reliable way for external tools to run prior to this point (without modifying the scene permanently).

This change simply invokes the VRCSDK's OnPreProcessAvatar hooks automatically when Av3Runtime initializes to resolve this issue.

This supercedes https://github.com/lyuma/Av3Emulator/pull/59 with a simpler approach.