### PR TITLE
Update FX Avatar Mask behaviour for VRC 2022.2.2p3

### DIFF
--- a/Scripts/LyumaAv3Runtime.cs
+++ b/Scripts/LyumaAv3Runtime.cs
@@ -1158,8 +1158,8 @@ public class LyumaAv3Runtime : MonoBehaviour
             {
                 ac = vrcAnimLayer.animatorController;
                 mask = vrcAnimLayer.mask;
-                if (vrcAnimLayer.type == VRCAvatarDescriptor.AnimLayerType.FX) {
-                    mask = animLayerToDefaultAvaMask[vrcAnimLayer.type]; // Force mask to prevent muscle overrides.
+                if (mask == null && vrcAnimLayer.type == VRCAvatarDescriptor.AnimLayerType.FX) {
+                    mask = animLayerToDefaultAvaMask[vrcAnimLayer.type]; // When empty, defaults to a mask that prevents muscle overrides.
                 }
             }
             if (ac == null) {


### PR DESCRIPTION
As of VRC 2022.2.2p3 (30 August 2022, SDK 2022.08.29.20.48), custom FX Avatar Masks are now uploaded for all layers of the FX controller. The previous behaviour of the top layer's mask being set to a mask that disables all humanoid muscles now only occurs if the mask in the controller is empty.

From the [patch notes](https://docs.vrchat.com/docs/vrchat-202222p3#features-changes-fixes-and-improvements):
> Fixed: user-supplied masks on the FX layer were ignored, and prevented Gesture transform animations from working. Docs updated: https://docs.vrchat.com/docs/playable-layers#fx

And part of the updated documentation:
> The mask in the first FX layer, by default is empty, this will (at avatar init) create a default mask that disables all humanoid muscles, but enables all GameObject animations.

The updated documentation could be clearer that the default mask is only created when you leave it empty.