### PR TITLE
Enable BlendShape clamping

### DIFF
--- a/Editor/LyumaAv3EditorSupport.cs
+++ b/Editor/LyumaAv3EditorSupport.cs
@@ -114,6 +114,11 @@ public static class LyumaAv3EditorSupport
         foreach (string guid in AssetDatabase.FindAssets("EmptyController")) {
             LyumaAv3Emulator.EmptyController = AssetDatabase.LoadAssetAtPath<RuntimeAnimatorController>(AssetDatabase.GUIDToAssetPath(guid));
         }
+        
+        // VRChat clamps BlendShapes in the [0, 100] range, but the user may not have this setting enabled
+        LyumaAv3Emulator.EnableClampBlendShapeWeightsDelegate = () => {
+            UnityEditor.PlayerSettings.legacyClampBlendShapeWeights = true;
+        };
 
         LyumaAv3Runtime.updateSelectionDelegate = (obj) => {
             if (obj == null && LyumaAv3Emulator.emulatorInstance != null) {

--- a/Scripts/LyumaAv3Emulator.cs
+++ b/Scripts/LyumaAv3Emulator.cs
@@ -25,6 +25,8 @@ using VRC.SDK3.Avatars.Components;
 public class LyumaAv3Emulator : MonoBehaviour
 {
     static readonly ulong EMULATOR_VERSION = 0x2_09_08_00;
+    public delegate void EnableClampBlendShapeWeightsDelegateType();
+    public static EnableClampBlendShapeWeightsDelegateType EnableClampBlendShapeWeightsDelegate;
 
     [Header("Fake VR or Desktop mode selection")]
     public bool DefaultToVR = false;
@@ -60,6 +62,7 @@ public class LyumaAv3Emulator : MonoBehaviour
 
     private void Awake()
     {
+        EnableClampBlendShapeWeightsDelegate();
         Animator animator = gameObject.GetOrAddComponent<Animator>();
         animator.enabled = false;
         animator.runtimeAnimatorController = EmptyController;


### PR DESCRIPTION
VRChat clamps BlendShapes in the [0,100] range, but the user may not have that setting enabled. Fixes #45

![image](https://user-images.githubusercontent.com/495015/196583443-5eb7aa28-5a20-4ffa-bc45-e8353c0faf0a.png)
(I tested it myself on the current patch as well)

This patch enables `UnityEditor.PlayerSettings.legacyClampBlendShapeWeights` in `LyumaAv3Emulator`'s `Awake` method via a delegate set by `LyumaAv3EditorSupport`'s `InitDefaults` function.

Upon exiting Play mode, Unity automatically restores the setting to its original value.

C# and Unity are not my forte, so I don't know if there's a better place to enable this setting, `LyumaAv3Emulator`'s `Awake` seems to work ok. And I tried to copy how the existing code was calling Editor specific code and did a test avatar upload with the patch just in-case.

The clamping setting is normally found in the Other Settings of the Player Settings:
![image](https://user-images.githubusercontent.com/495015/196587093-d01709ac-cd22-4c5e-846b-7f9952fe1828.png)

