### PR TITLE
Fixed Action controller's GUID.

### DIFF
--- a/Editor/LyumaAv3EditorSupport.cs
+++ b/Editor/LyumaAv3EditorSupport.cs
@@ -49,7 +49,7 @@ public static class LyumaAv3EditorSupport
         {VRCAvatarDescriptor.AnimLayerType.Sitting, "1268460c14f873240981bf15aa88b21a"},
         {VRCAvatarDescriptor.AnimLayerType.Additive, "573a1373059632b4d820876efe2d277f"},
         {VRCAvatarDescriptor.AnimLayerType.FX, "d40be620cf6c698439a2f0a5144919fe"},
-        {VRCAvatarDescriptor.AnimLayerType.Action, "d5aeb52dc5e89244abdb9da8296fad0b"},
+        {VRCAvatarDescriptor.AnimLayerType.Action, "3e479eeb9db24704a828bffb15406520"},
         {VRCAvatarDescriptor.AnimLayerType.Gesture, "404d228aeae421f4590305bc4cdaba16"},
     };
     static Dictionary<VRCAvatarDescriptor.AnimLayerType, string> animLayerToDefaultAvaMaskFile = new Dictionary<VRCAvatarDescriptor.AnimLayerType, string>


### PR DESCRIPTION
I'm getting this message:
> Failed to resolve animator controller vrc_AvatarV3ActionLayer for Action

Idk where did the `d5aeb52dc5e89244abdb9da8296fad0b` GUID come from, but both Assets- and Packages-based SDKs in the current and a couple of previous versions have this file with `3e479eeb9db24704a828bffb15406520` GUID.

It would probably not give that warning with the Assets-based SDK, if not for the `sSADASASDASD` at the end of the path-based lookup. Alternative fixes for that in #69 and #70.