### PR TITLE
Cleaned animator lookup to only use the GUIDs.

### DIFF
--- a/Editor/LyumaAv3EditorSupport.cs
+++ b/Editor/LyumaAv3EditorSupport.cs
@@ -71,13 +71,8 @@ namespace Lyuma.Av3Emulator.Editor
                     LyumaAv3Runtime.animLayerToDefaultController[kv.Key] = null;
                 } else
                 {
-                    //Debug.Log("{VRCAvatarDescriptor.AnimLayerType." + kv.Value + ", \"" + AssetDatabase.AssetPathToGUID("Assets/VRCSDK/Examples3/Animation/Controllers/" + kv.Value + ".controller") + "\"},");
-                    AnimatorController ac = AssetDatabase.LoadAssetAtPath<AnimatorController>("Assets/VRCSDK/Examples3/Animation/Controllers/" + kv.Value + ".controllersSADASASDASD");
-                    if (ac == null)
-                    {
-                        string SDKPath = AssetDatabase.GUIDToAssetPath(animLayerToDefaultGUID[kv.Key]);
-                        ac = AssetDatabase.LoadAssetAtPath<AnimatorController>(SDKPath);
-                    }
+                    string SDKPath = AssetDatabase.GUIDToAssetPath(animLayerToDefaultGUID[kv.Key]);
+                    AnimatorController ac = AssetDatabase.LoadAssetAtPath<AnimatorController>(SDKPath);
                     if (ac == null)
                     {
                         Debug.LogWarning("Failed to resolve animator controller " + kv.Value + " for " + kv.Key);


### PR DESCRIPTION
The initial path-based lookup doesn't work currently because of the (debug?) `sSADASASDASD` at the end anyway.

If you don't wanna get rid of the path-based lookup, an alternative fix is in #70 .