### PR TITLE
Fixed animator lookup.

### DIFF
--- a/Editor/LyumaAv3EditorSupport.cs
+++ b/Editor/LyumaAv3EditorSupport.cs
@@ -71,8 +71,7 @@ namespace Lyuma.Av3Emulator.Editor
                     LyumaAv3Runtime.animLayerToDefaultController[kv.Key] = null;
                 } else
                 {
-                    //Debug.Log("{VRCAvatarDescriptor.AnimLayerType." + kv.Value + ", \"" + AssetDatabase.AssetPathToGUID("Assets/VRCSDK/Examples3/Animation/Controllers/" + kv.Value + ".controller") + "\"},");
-                    AnimatorController ac = AssetDatabase.LoadAssetAtPath<AnimatorController>("Assets/VRCSDK/Examples3/Animation/Controllers/" + kv.Value + ".controllersSADASASDASD");
+                    AnimatorController ac = AssetDatabase.LoadAssetAtPath<AnimatorController>("Assets/VRCSDK/Examples3/Animation/Controllers/" + kv.Value + ".controller");
                     if (ac == null)
                     {
                         string SDKPath = AssetDatabase.GUIDToAssetPath(animLayerToDefaultGUID[kv.Key]);


### PR DESCRIPTION
Removes the `sSADASASDASD` at the end of looked up controllers' names.

To get rid of the path-based lookup altogether, an alternative solution is in #69 .