### PR TITLE
fix: av3emu changed gui skin globally

### DIFF
--- a/Editor/LyumaAv3MenuEditor.cs
+++ b/Editor/LyumaAv3MenuEditor.cs
@@ -32,6 +32,13 @@ namespace Lyuma.Av3Emulator.Editor
     {
         private VRCExpressionsMenu _currentMenu;
 
+        static class Styles
+        {
+            public static readonly GUIStyle ParameterizedButtonStyle = new GUIStyle(GUI.skin.button)
+                { richText = true };
+        }
+
+
         public override void OnInspectorGUI()
         {
             var menu = (LyumaAv3Menu)target;
@@ -316,9 +323,9 @@ namespace Lyuma.Av3Emulator.Editor
         private bool ParameterizedButton(VRCExpressionsMenu.Control control, string parameterName, float wantedValue)
         {
             var hasParameter = IsValidParameterName(parameterName);
-            GUIStyle style = GUI.skin.button;
-            style.richText = true;
-            return GUILayout.Button(new GUIContent(control.name + (hasParameter ? " (" + parameterName + " = " + wantedValue + ")" : ""), control.icon), style, GUILayout.Height(36),GUILayout.MinWidth(40));
+            return GUILayout.Button(
+                new GUIContent(control.name + (hasParameter ? " (" + parameterName + " = " + wantedValue + ")" : ""),
+                    control.icon), Styles.ParameterizedButtonStyle, GUILayout.Height(36), GUILayout.MinWidth(40));
         }
 
         private static T GreenBackground<T>(bool isActive, Func<T> inside)


### PR DESCRIPTION
87a1d4f adds support for rich text in ParameterizedButton. However previous fix changes style for gui globally (this means buttons on other ui will also have richText support). That is not good so I fixed this problem.

To avoid creating GUIStyle every frame, I'm using Styles inner class which is used generally in UnityCsReference. e.g. [here](https://github.com/Unity-Technologies/UnityCsReference/blob/a6fa5178d090c0c727b4e0b03e324c118318c3cd/Editor/Mono/GUI/Toolbar.cs#L37C2-L45)

Because instantiating GUIStyle is not allowed outside of GUI callbacks we cannot initialize GUIStyle in static initializer of Editor class. (editor class will be initialized outside of GUI callbacks). 
Instead, I can use separated class to initialize a class in the GUI callback if we don't access that class outside of GUI callbacks.