### PR TITLE
Make package manifest follow packge naming rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "lyuma.av3emulator",
+  "name": "com.lyuma.av3emulator",
   "displayName": "Av3Emulator",
   "version": "2.9.11",
   "description": "An Emulator for VRChat's Avatar 3.0 System",
@@ -9,7 +9,7 @@
   },
   "legacyFolders": {},
   "legacyFiles": {},
-  "localPath": ".\\Packages\\lyuma.av3emulator",
+  "localPath": ".\\Packages\\com.lyuma.av3emulator",
   "type": "tool",
   "unity": "2019.4"
 }


### PR DESCRIPTION
packages should always have 3 (or more) segments
e.g.
com.vrchat.base
com.spoiledcat.git
com.mischief.markdownviewer
com.innogames.asset-relations-viewer

This is necessary for OpenUPM publishing. VPM and the UPM in unity will accept malformed packages, but correcting this would be good. 
See: https://github.com/openupm/openupm/pull/3794