### PR TITLE
Disable expression menu when not in parameters

### DIFF
--- a/Editor/LyumaAv3MenuEditor.cs
+++ b/Editor/LyumaAv3MenuEditor.cs
@@ -102,28 +102,40 @@ namespace Lyuma.Av3Emulator.Editor
 			for (var controlIndex = 0; controlIndex < _currentMenu.controls.Count; controlIndex++)
 			{
 				var control = _currentMenu.controls[controlIndex];
-				switch (control.type)
+				bool parametersIncorrect = menu.Runtime.expressionParamNames != null &&
+				                           ((control.parameter.name != "" &&
+				                             !menu.Runtime.expressionParamNames.Contains(control.parameter.name))
+				                            || !control.subParameters.All(x =>
+					                            x == null || x.name == "" || menu.Runtime.expressionParamNames.Contains(x.name)));
+				if (parametersIncorrect)
 				{
-					case VRCExpressionsMenu.Control.ControlType.Button:
-						FromToggle(control, "Button");
-						break;
-					case VRCExpressionsMenu.Control.ControlType.Toggle:
-						FromToggle(control, "Toggle");
-						break;
-					case VRCExpressionsMenu.Control.ControlType.SubMenu:
-						FromSubMenu(control);
-						break;
-					case VRCExpressionsMenu.Control.ControlType.TwoAxisPuppet:
-						FromTwoAxis(control, controlIndex);
-						break;
-					case VRCExpressionsMenu.Control.ControlType.FourAxisPuppet:
-						FromFourAxis(control, controlIndex);
-						break;
-					case VRCExpressionsMenu.Control.ControlType.RadialPuppet:
-						FromRadial(control, controlIndex);
-						break;
-					default:
-						throw new ArgumentOutOfRangeException();
+					GUILayout.Label(new GUIContent("Parameter not found in expression parameters for: " + control.name), Styles.ParameterizedButtonStyle, GUILayout.Height(36), GUILayout.MinWidth(40));
+				}
+				else
+				{
+					switch (control.type)
+					{
+						case VRCExpressionsMenu.Control.ControlType.Button:
+							FromToggle(control, "Button");
+							break;
+						case VRCExpressionsMenu.Control.ControlType.Toggle:
+							FromToggle(control, "Toggle");
+							break;
+						case VRCExpressionsMenu.Control.ControlType.SubMenu:
+							FromSubMenu(control);
+							break;
+						case VRCExpressionsMenu.Control.ControlType.TwoAxisPuppet:
+							FromTwoAxis(control, controlIndex);
+							break;
+						case VRCExpressionsMenu.Control.ControlType.FourAxisPuppet:
+							FromFourAxis(control, controlIndex);
+							break;
+						case VRCExpressionsMenu.Control.ControlType.RadialPuppet:
+							FromRadial(control, controlIndex);
+							break;
+						default:
+							throw new ArgumentOutOfRangeException();
+					}
 				}
 			}
 

--- a/Runtime/Scripts/LyumaAv3Runtime.cs
+++ b/Runtime/Scripts/LyumaAv3Runtime.cs
@@ -102,6 +102,7 @@ namespace Lyuma.Av3Emulator.Runtime
 		Animator animator;
 		private RuntimeAnimatorController origAnimatorController;
 		public Dictionary<VRCAvatarDescriptor.AnimLayerType, RuntimeAnimatorController> allControllers = new Dictionary<VRCAvatarDescriptor.AnimLayerType, RuntimeAnimatorController>();
+		public HashSet<string> expressionParamNames = new HashSet<string>();
 
 		private Transform[] allTransforms;
 		private Transform[] allMirrorTransforms;
@@ -1519,6 +1520,12 @@ namespace Lyuma.Av3Emulator.Runtime
 			foreach (var comp in avadesc.gameObject.GetComponents<LyumaAv3Menu>()) {
 				UnityEngine.Object.Destroy(comp);
 			}
+
+			if (stageParameters != null)
+			{
+				expressionParamNames = new HashSet<string>(stageParameters.parameters.Select(x => x.name));
+			}
+
 			LyumaAv3Menu mainMenu;
 			mainMenu = avadesc.gameObject.AddComponent<GestureManagerAv3Menu>();
 			if (emulator != null) {


### PR DESCRIPTION
This doesn't matter much since vrchat doesnt let you upload it anyways, but we replace menus that act on parameters that don't exist with a label telling the user their menu doesn't work since a parameter is not found.

Fixes #76 