### PR TITLE
Change semver dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "Assets\\Lyuma\\Av3Emulator" : "e42c5d0b3e2b3f64e8a88c225b3cef62"
   },
   "vpmDependencies": {
-    "com.vrchat.avatars": "^3.1.0"
+    "com.vrchat.avatars": ">=3.1.0 <3.3.0"
   },
   "legacyFolders": {},
   "legacyFiles": {},

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "Assets\\Lyuma\\Av3Emulator" : "e42c5d0b3e2b3f64e8a88c225b3cef62"
   },
   "vpmDependencies": {
-    "com.vrchat.avatars": "3.1.x"
+    "com.vrchat.avatars": "^3.1.0"
   },
   "legacyFolders": {},
   "legacyFiles": {},


### PR DESCRIPTION
^3.1.0 means >=3.1.0 < 4.0.0, 
since according to the semantic versioning spec, they shouldn't release any breaking changes in the current major version, so our current version should technically work even with 3.17.56

