### PR TITLE
Fix viseme tracking behaviour

### DIFF
--- a/Runtime/Scripts/LyumaAv3Runtime.cs
+++ b/Runtime/Scripts/LyumaAv3Runtime.cs
@@ -2047,6 +2047,8 @@ namespace Lyuma.Av3Emulator.Runtime
 			}
 			if (IKTrackingOutputData.trackingMouthAndJaw == VRC_AnimatorTrackingControl.TrackingType.Animation)
 			{
+				// In VRC, when you set the Mouth & Jaw to Animation, it will freeze the viseme value. This replicates that behaviour
+				// See https://github.com/lyuma/Av3Emulator/issues/109
 				Viseme = (VisemeIndex)VisemeInt;
 				VisemeIdx = VisemeInt;
 			}

--- a/Runtime/Scripts/LyumaAv3Runtime.cs
+++ b/Runtime/Scripts/LyumaAv3Runtime.cs
@@ -2044,6 +2044,11 @@ namespace Lyuma.Av3Emulator.Runtime
 				playableBlendingStates[ikposeIndex].StartBlend(playableMixer.GetInputWeight(ikposeIndex + 1), IKPoseCalibration ? 1f : 0f, 0.0f);
 				PrevIKPoseCalibration = IKPoseCalibration;
 			}
+			if (IKTrackingOutputData.trackingMouthAndJaw == VRC_AnimatorTrackingControl.TrackingType.Animation)
+			{
+				Viseme = (VisemeIndex)VisemeInt;
+				VisemeIdx = VisemeInt;
+			}
 			if (VisemeIdx != VisemeInt) {
 				VisemeInt = VisemeIdx;
 				Viseme = (VisemeIndex)VisemeInt;

--- a/Runtime/Scripts/LyumaAv3Runtime.cs
+++ b/Runtime/Scripts/LyumaAv3Runtime.cs
@@ -31,6 +31,7 @@ using VRC.SDK3.Avatars.Components;
 using VRC.SDK3.Avatars.ScriptableObjects;
 using VRC.SDK3.Dynamics.Contact.Components;
 using VRC.SDK3.Dynamics.PhysBone.Components;
+using VRC.SDKBase;
 using static VRC.SDK3.Avatars.ScriptableObjects.VRCExpressionParameters;
 
 namespace Lyuma.Av3Emulator.Runtime


### PR DESCRIPTION
In VRC, when you set the Mouth & Jaw to Animation, it will freeze the viseme value. This PR replicates that behaviour

Fixes #109 