### PR TITLE
defer initialize Av3Emulator to Start

### DIFF
--- a/Runtime/Scripts/LyumaAv3Emulator.cs
+++ b/Runtime/Scripts/LyumaAv3Emulator.cs
@@ -183,15 +183,13 @@ namespace Lyuma.Av3Emulator.Runtime
 			Camera.onPreCull += PreCull;
 			Camera.onPostRender += PostRender;
 			emulatorInstance = this;
-			ScanForAvatars();
 			if (WorkaroundPlayModeScriptCompile) {
 				LyumaAv3Runtime.ApplyOnEnableWorkaroundDelegate();
 			}
-
-			SceneManager.sceneLoaded += OnSceneLoaded;
 		}
 
-		private void OnSceneLoaded(Scene scene, LoadSceneMode mode) {
+		private void Start()
+		{
 			ScanForAvatars();
 		}
 
@@ -287,7 +285,6 @@ namespace Lyuma.Av3Emulator.Runtime
 			}
 			runtimes.Clear();
 			LyumaAv3Runtime.updateSceneLayersDelegate(~0);
-			SceneManager.sceneLoaded -= OnSceneLoaded;
 		}
 
 		private void Update() {


### PR DESCRIPTION
Initializing Av3Emulator in Awake will cause incompatibility with tools applied on IProcessSceneWithReport.

Awake is very very early state in scene initialization which can (not always) be before IProcessSceneWithReport, a unity official way to modify scene before game execution.
Is there any reason ~~OnSceneLoad~~ Start is too late?