### PR TITLE
Defer initialization until after Start

### DIFF
--- a/Editor/LyumaAv3EditorSupport.cs
+++ b/Editor/LyumaAv3EditorSupport.cs
@@ -235,9 +235,20 @@ namespace Lyuma.Av3Emulator.Editor
 					.Select(x => x.gameObject)
 					.Where(x => x.activeSelf).ToList();
 
+				bool emulatorEnabled = false;
+				
 				foreach (var lyumaAv3Emulator in GameObject.FindObjectsOfType<LyumaAv3Emulator>())
 				{
+					emulatorEnabled = true;
 					lyumaAv3Emulator.AvatarList = avatars;
+				}
+
+				if (emulatorEnabled)
+				{
+					foreach (var gameObject in avatars)
+					{
+						gameObject.SetActive(false);
+					}
 				}
 			}
 
@@ -249,7 +260,6 @@ namespace Lyuma.Av3Emulator.Editor
 					foreach (var gameObject in lyumaAv3Emulator.AvatarList)
 					{
 						gameObject.SetActive(true);
-
 					}
 				}
 			}

--- a/Editor/LyumaAv3EditorSupport.cs
+++ b/Editor/LyumaAv3EditorSupport.cs
@@ -228,7 +228,7 @@ namespace Lyuma.Av3Emulator.Editor
 				CompilationPipeline.assemblyCompilationStarted -= WorkaroundDestroyManagersBeforeCompile;
 			}
 
-			// Writing all disabled objects into SessionState
+			// Saving all avatars into the AV3 Emulators
 			if (pmsc == PlayModeStateChange.ExitingEditMode)
 			{
 				List<GameObject> avatars = GameObject.FindObjectsOfType<VRCAvatarDescriptor>()
@@ -252,7 +252,7 @@ namespace Lyuma.Av3Emulator.Editor
 				}
 			}
 
-			// Obtaining disabled objects from SessionState and enabling them
+			// Obtaining disabled objects from AV3 Emulator and enabling them
 			if (pmsc == PlayModeStateChange.EnteredEditMode)
 			{
 				foreach (var lyumaAv3Emulator in GameObject.FindObjectsOfType<LyumaAv3Emulator>())

--- a/Editor/LyumaAv3EditorSupport.cs
+++ b/Editor/LyumaAv3EditorSupport.cs
@@ -261,6 +261,8 @@ namespace Lyuma.Av3Emulator.Editor
 					{
 						gameObject.SetActive(true);
 					}
+
+					lyumaAv3Emulator.AvatarList = new List<GameObject>();
 				}
 			}
 		}

--- a/Editor/LyumaAv3EditorSupport.cs
+++ b/Editor/LyumaAv3EditorSupport.cs
@@ -19,12 +19,14 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. */
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using Lyuma.Av3Emulator.Runtime;
 using UnityEditor;
 using UnityEditor.Animations;
 using UnityEditor.Compilation;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 using static Lyuma.Av3Emulator.Runtime.LyumaAv3Emulator;
 using VRC.SDK3.Avatars.Components;
 using VRC.SDKBase.Editor.BuildPipeline;
@@ -221,8 +223,35 @@ namespace Lyuma.Av3Emulator.Editor
 
 		public static void OnPlayModeStateChange(UnityEditor.PlayModeStateChange pmsc) {
 			// We don't want any of our callbacks causing trouble outside of play mode.
-			if (pmsc != UnityEditor.PlayModeStateChange.EnteredPlayMode) {
+			if (pmsc != UnityEditor.PlayModeStateChange.EnteredPlayMode)
+			{
 				CompilationPipeline.assemblyCompilationStarted -= WorkaroundDestroyManagersBeforeCompile;
+			}
+
+			// Writing all disabled objects into SessionState
+			if (pmsc == PlayModeStateChange.ExitingEditMode)
+			{
+				List<GameObject> avatars = GameObject.FindObjectsOfType<VRCAvatarDescriptor>()
+					.Select(x => x.gameObject)
+					.Where(x => x.activeSelf).ToList();
+
+				foreach (var lyumaAv3Emulator in GameObject.FindObjectsOfType<LyumaAv3Emulator>())
+				{
+					lyumaAv3Emulator.AvatarList = avatars;
+				}
+			}
+
+			// Obtaining disabled objects from SessionState and enabling them
+			if (pmsc == PlayModeStateChange.EnteredEditMode)
+			{
+				foreach (var lyumaAv3Emulator in GameObject.FindObjectsOfType<LyumaAv3Emulator>())
+				{
+					foreach (var gameObject in lyumaAv3Emulator.AvatarList)
+					{
+						gameObject.SetActive(true);
+
+					}
+				}
 			}
 		}
 

--- a/Runtime/Scripts/LyumaAv3Emulator.cs
+++ b/Runtime/Scripts/LyumaAv3Emulator.cs
@@ -87,9 +87,9 @@ namespace Lyuma.Av3Emulator.Runtime
 		public bool ApplyClonePositionOffset = false;
 
 		static public LyumaAv3Emulator emulatorInstance;
-		public List<GameObject> AvatarList = new List<GameObject>();
-		public bool InitNextFrame = false;
-		public bool Init = false;
+		[HideInInspector] public List<GameObject> AvatarList = new List<GameObject>();
+		private bool InitNextFrame = false;
+		private bool Init = false;
 		static public RuntimeAnimatorController EmptyController;
 
 		[NonSerialized] public List<LyumaAv3Runtime> runtimes = new List<LyumaAv3Runtime>();

--- a/Runtime/Scripts/LyumaAv3Emulator.cs
+++ b/Runtime/Scripts/LyumaAv3Emulator.cs
@@ -87,6 +87,9 @@ namespace Lyuma.Av3Emulator.Runtime
 		public bool ApplyClonePositionOffset = false;
 
 		static public LyumaAv3Emulator emulatorInstance;
+		public List<GameObject> AvatarList = new List<GameObject>();
+		public bool InitNextFrame = false;
+		public bool Init = false;
 		static public RuntimeAnimatorController EmptyController;
 
 		[NonSerialized] public List<LyumaAv3Runtime> runtimes = new List<LyumaAv3Runtime>();
@@ -177,30 +180,42 @@ namespace Lyuma.Av3Emulator.Runtime
 				}
 			}
 		}
-
-		private void Awake()
+		
+		private void Start()
 		{
 			Camera.onPreCull += PreCull;
 			Camera.onPostRender += PostRender;
 			emulatorInstance = this;
-			ScanForAvatars();
+			RunPreprocessors();
 			if (WorkaroundPlayModeScriptCompile) {
 				LyumaAv3Runtime.ApplyOnEnableWorkaroundDelegate();
 			}
 
-			SceneManager.sceneLoaded += OnSceneLoaded;
+			InitNextFrame = true;
 		}
 
-		private void OnSceneLoaded(Scene scene, LoadSceneMode mode) {
-			ScanForAvatars();
+		private void RunPreprocessors()
+		{
+			List<GameObject> avatars = AvatarList;
+			foreach (var avadesc in avatars)
+			{
+				bool alreadyHadComponent = avadesc.gameObject.GetComponent<LyumaAv3Runtime>() != null;
+				if (RunPreprocessAvatarHook && !alreadyHadComponent)
+				{
+					GameObject origClone = GameObject.Instantiate(avadesc.gameObject);
+					origClone.name = avadesc.gameObject.name;
+					avadesc.gameObject.name = origClone.name + "(Clone)";
+					LyumaAv3Runtime.InvokeOnPreProcessAvatar(avadesc.gameObject);
+					avadesc.gameObject.name = origClone.name;
+					GameObject.DestroyImmediate(origClone);
+				}
+			}
 		}
-
-		private void ScanForAvatars() {
-			VRCAvatarDescriptor[] avatars = FindObjectsOfType<VRCAvatarDescriptor>()
-				.Where(avatar => !scannedAvatars.Contains(avatar))
-				.ToArray();
-			scannedAvatars.UnionWith(avatars);
-			Debug.Log(this.name + ": Setting up Av3Emulator on "+avatars.Length + " avatars.", this);
+		
+		private void Initialize()
+		{
+			List<GameObject> avatars = AvatarList;
+			Debug.Log(this.name + ": Setting up Av3Emulator on " + avatars.Count + " avatars.", this);
 			foreach (var avadesc in avatars)
 			{
 				if (avadesc.GetComponent<PipelineSaver>() != null) {
@@ -213,16 +228,6 @@ namespace Lyuma.Av3Emulator.Runtime
 				try {
 					// Creates the playable director, and initializes animator.
 					bool alreadyHadComponent = avadesc.gameObject.GetComponent<LyumaAv3Runtime>() != null;
-					if (RunPreprocessAvatarHook && !alreadyHadComponent) {
-						GameObject origClone = GameObject.Instantiate(avadesc.gameObject);
-						origClone.name = avadesc.gameObject.name;
-						avadesc.gameObject.name = origClone.name + "(Clone)";
-						LyumaAv3Runtime.InvokeOnPreProcessAvatar(avadesc.gameObject);
-						avadesc.gameObject.name = origClone.name;
-						GameObject.DestroyImmediate(origClone);
-						avadesc.gameObject.SetActive(true);
-					}
-
 					var oml = GetOrAddComponent<UnityEngine.AI.OffMeshLink>(avadesc.gameObject);
 					oml.startTransform = this.transform;
 					var runtime = GetOrAddComponent<LyumaAv3Runtime>(avadesc.gameObject);
@@ -287,13 +292,24 @@ namespace Lyuma.Av3Emulator.Runtime
 			}
 			runtimes.Clear();
 			LyumaAv3Runtime.updateSceneLayersDelegate(~0);
-			SceneManager.sceneLoaded -= OnSceneLoaded;
 		}
 
 		private void Update() {
+			if (InitNextFrame)
+			{
+				InitNextFrame = false;
+				Init = true;
+				return;
+			}
+
+			if (Init)
+			{
+				Init = false;
+				Initialize();
+			}
 			if (RestartingEmulator) {
 				RestartingEmulator = false;
-				Awake();
+				Initialize();
 			} else if (RestartEmulator) {
 				RunPreprocessAvatarHook = false;
 				RestartEmulator = false;

--- a/Runtime/Scripts/LyumaAv3Emulator.cs
+++ b/Runtime/Scripts/LyumaAv3Emulator.cs
@@ -218,6 +218,7 @@ namespace Lyuma.Av3Emulator.Runtime
 			Debug.Log(this.name + ": Setting up Av3Emulator on " + avatars.Count + " avatars.", this);
 			foreach (var avadesc in avatars)
 			{
+				avadesc.SetActive(true);
 				if (avadesc.GetComponent<PipelineSaver>() != null) {
 					Debug.Log("Found PipelineSaver on " + avadesc.name + ". Disabling clones and mirror copy.", avadesc);
 					DisableMirrorClone = true;


### PR DESCRIPTION
The proposed workflow now is:
Exit Edit Mode: Disable objects and record list in Av3Emulator
Av3Emulator Start: Loop through objects in list in Av3Emulator, and Run Preprocess Hooks.
WaitForNextFrame: Create mirror clone, AddComponent Av3Runtime, then enable objects (which calls Awake and assigns playable graphs etc?)
Enter Edit Mode: Enable objects in list in Av3Emulator, then clear the list.