### PR TITLE
Fix: null can be added to preprocessAvatarCallbacks

### DIFF
--- a/Editor/LyumaAv3EditorSupport.cs
+++ b/Editor/LyumaAv3EditorSupport.cs
@@ -300,7 +300,7 @@ namespace Lyuma.Av3Emulator.Editor
 				}
 				finally
 				{
-					if (lockMaterials != null);
+					if (lockMaterials != null)
 					{
 						_preprocessAvatarCallbacks.Add(lockMaterials);
 					}	


### PR DESCRIPTION
With enter play mode reload domain off, entering play mode twice will cause NullReferenceException