### PR TITLE
feat: minimum support for `IsOnFriendsList`

### DIFF
--- a/Runtime/Scripts/LyumaAv3Runtime.cs
+++ b/Runtime/Scripts/LyumaAv3Runtime.cs
@@ -432,7 +432,7 @@ namespace Lyuma.Av3Emulator.Runtime
 				runtime => Mathf.Clamp((runtime.avadesc.ViewPosition.y  - 0.2f)/ (5.0f - 0.2f), 0.0f, 1.0f),
 				(runtime, value) => { }), //Modifying this doesn't make sense, this field is un-editable in VRC
 			new BuiltinParameterDefinition("IsOnFriendsList", VRCExpressionParameters.ValueType.Bool, 
-				runtime => true, // always true for now.
+				runtime => !runtime.IsLocal, // true for remote and false for local 
 				(runtime, value) => { }), //Modifying this doesn't make sense, this field is un-editable in VRC
 		};
 		

--- a/Runtime/Scripts/LyumaAv3Runtime.cs
+++ b/Runtime/Scripts/LyumaAv3Runtime.cs
@@ -430,7 +430,10 @@ namespace Lyuma.Av3Emulator.Runtime
 				(runtime, value) => { }), //Modifying this doesn't make sense, this field is un-editable in VRC
 			new BuiltinParameterDefinition("EyeHeightAsPercent", VRCExpressionParameters.ValueType.Float, 
 				runtime => Mathf.Clamp((runtime.avadesc.ViewPosition.y  - 0.2f)/ (5.0f - 0.2f), 0.0f, 1.0f),
-				(runtime, value) => { }) //Modifying this doesn't make sense, this field is un-editable in VRC
+				(runtime, value) => { }), //Modifying this doesn't make sense, this field is un-editable in VRC
+			new BuiltinParameterDefinition("IsOnFriendsList", VRCExpressionParameters.ValueType.Bool, 
+				runtime => true, // always true for now.
+				(runtime, value) => { }), //Modifying this doesn't make sense, this field is un-editable in VRC
 		};
 		
 		public static readonly Type[] MirrorCloneComponentBlacklist = new Type[] {


### PR DESCRIPTION
Fixes #137 

Since there is no emulation for friend / non-friend, I make `IsOnFriendsList` always true.

I think it's not good to have some toggle to switch `IsOnFriendsList` because I think camera should be remoed with `IsOnFriendsList` = false avatars.