### PR TITLE
Fix scaling offset on parent constraints being wrong with changed scale

### DIFF
--- a/Runtime/Scripts/LyumaAv3Runtime.cs
+++ b/Runtime/Scripts/LyumaAv3Runtime.cs
@@ -1187,7 +1187,12 @@ namespace Lyuma.Av3Emulator.Runtime
 			DefaultViewPosition = avadesc.ViewPosition;
 			DefaultAvatarScale = gameObject.transform.localScale;
 
-			ParentConstraints = gameObject.GetComponentsInChildren<ParentConstraint>(true).Select(x => (x, x.translationOffsets)).ToArray();
+			ParentConstraints = gameObject.GetComponentsInChildren<ParentConstraint>(true)
+				.Select(constraint => (constraint, constraint.translationOffsets.Select(offset =>
+				{
+					Vector3 lossyScale = constraint.transform.lossyScale;
+					return new Vector3(offset.x / lossyScale.x, offset.y / lossyScale.y, offset.z / lossyScale.z); // We want offsets to be in world space;
+				}).ToArray())).ToArray();
 			ClothComponents = gameObject.GetComponentsInChildren<Cloth>(true).ToArray();
 		}
 


### PR DESCRIPTION
We were modifying parent constraints wrong when scale wasn't 1,1,1, since our offsets were in local space but treated as if they were in world space.