### PR TITLE
Fix mirror detection after restart

### DIFF
--- a/Runtime/Scripts/LyumaAv3Runtime.cs
+++ b/Runtime/Scripts/LyumaAv3Runtime.cs
@@ -1746,8 +1746,7 @@ namespace Lyuma.Av3Emulator.Runtime
 			// Plays the Graph.
 			playableGraph.SetTimeUpdateMode(DirectorUpdateMode.GameTime);
 			Debug.Log(this.name + " : " + GetType() + " awoken and ready to Play.", this);
-			playableGraph.Play();
-		}
+		}	
 
 		Dictionary<string, float> EarlyRefreshExpressionParameters() {
 			Dictionary<string, float> stageNameToValue = new Dictionary<string, float>();
@@ -2174,8 +2173,8 @@ namespace Lyuma.Av3Emulator.Runtime
 		}
 
 		void Update() {
-			if ((IsMirrorClone || IsShadowClone) && frameIndex == 0) playableGraph.Stop();
-			if ((IsMirrorClone || IsShadowClone) && frameIndex == 1) playableGraph.Play();
+			if (!(IsMirrorClone || IsShadowClone) && frameIndex == 1) playableGraph.Play();
+			if ((IsMirrorClone || IsShadowClone) && frameIndex == 2) playableGraph.Play();
 			frameIndex += 1;
 			if (animator == null)
 			{


### PR DESCRIPTION
if we restart the emulator using the Emulator Control's restart option, it breaks mirror detection (and islocal detection as well)

This fix fixes that by waiting for 1 frame always to make isLocal set on time.

(Note: this always happens when using vrcfury or having preprocessor hooks enabled with it in the project, which is a big portion of all avatars out there)