### PR TITLE
Fix types being set wrong

### DIFF
--- a/Runtime/Scripts/LyumaAv3Runtime.cs
+++ b/Runtime/Scripts/LyumaAv3Runtime.cs
@@ -2832,8 +2832,8 @@ namespace Lyuma.Av3Emulator.Runtime
 									param.exportedValue = param.value;
 								}
 							}
+							paramterFloats[paramid] = param.value;
 						}
-						paramterFloats[paramid] = param.value;
 					}
 				}
 				foreach (IntParam param in Ints)
@@ -2847,8 +2847,8 @@ namespace Lyuma.Av3Emulator.Runtime
 								param.value = i;
 								param.lastValue = param.value;
 							}
+							paramterInts[paramid] = param.value;
 						}
-						paramterInts[paramid] = param.value;
 					}
 				}
 				foreach (BoolParam param in Bools)
@@ -2862,8 +2862,8 @@ namespace Lyuma.Av3Emulator.Runtime
 								param.value = b;
 								param.lastValue = param.value;
 							}
+							paramterBools[paramid] = param.value;
 						}
-						paramterBools[paramid] = param.value;
 					}
 				}
 				


### PR DESCRIPTION
Since we use a TryGetValue into the float/int/bool array to see if it's the right type, this value shouldnt be set if it isnt a parameter of that type.

In rare cases if you had one parameter with different types across different controllers this could cause errors