### PR TITLE
Fix non-local clone regression caused by #185.

### DIFF
--- a/Runtime/Scripts/LyumaAv3Runtime.cs
+++ b/Runtime/Scripts/LyumaAv3Runtime.cs
@@ -1859,9 +1859,9 @@ namespace Lyuma.Av3Emulator.Runtime
 						continue;
 					}
 					string stageName = stageParam.name + (networkSynced ? stageParam.saved ? " (saved/SYNCED)" : " (SYNCED)" : stageParam.saved ? " (saved/local)" : " (local)"); //"Stage" + stageId;
-					float lastDefault = 0.0f;
-					if (AvatarSyncSource == this || !networkSynced) {
-						lastDefault = (stageParam.saved && KeepSavedParametersOnReset && stageNameToValue.ContainsKey(stageName) ? stageNameToValue[stageName] : stageParam.defaultValue);
+					float lastDefault = stageParam.defaultValue;
+					if ((AvatarSyncSource == this || !networkSynced) && stageParam.saved && KeepSavedParametersOnReset && stageNameToValue.ContainsKey(stageName)) {
+						lastDefault = stageNameToValue[stageName];
 					}
 					if (ParameterNames.Contains(stageParam.name)) {
 						Debug.LogWarning("Duplicate Expression Parameter Found: " + stageName + ", using the first one in the Expression Parameters.");


### PR DESCRIPTION
PR #185 caused a regression for non-local clones, causing some of their expression parameters to initialize in animator to 0/false until the first sync, this addresses that by ensuring they initialize to the default value set in expression parameters.

Side note: Clones still initialize with animator default values instead of the expression parameter default, I could not figure out how to address that before the clone appeared, I have tried inserting `SetTypeWithMismatch` calls at https://github.com/DorCoMaNdO/Av3Emulator/blob/b55c5c2ea8554a4ea2772e68b9dad97df4b3be19/Runtime/Scripts/LyumaAv3Runtime.cs#L1950, verified that the values were set, but the avatar still appeared with the animator default values first, the value changes only applied 2 frames after the clone spawned. Changing the parameter defaults in the animator does address this, and this can be done at runtime by cloning the animator before https://github.com/DorCoMaNdO/Av3Emulator/blob/b55c5c2ea8554a4ea2772e68b9dad97df4b3be19/Runtime/Scripts/LyumaAv3Runtime.cs#L1725, but there might be a better/simpler way that someone more knowledgeable at this part of Unity might know about, so I have not included that in this PR.